### PR TITLE
Source server updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3348,8 +3348,8 @@
       }
     },
     "css-loader": {
-      "version": "github:npetruzzelli-forks/css-loader#625ffb1f06d029aed9b900dfee2b3c1ce6ad2c6d",
-      "from": "github:npetruzzelli-forks/css-loader#625ffb1f06d029aed9b900dfee2b3c1ce6ad2c6d",
+      "version": "1.0.1",
+      "resolved": "github:npetruzzelli-forks/css-loader#625ffb1f06d029aed9b900dfee2b3c1ce6ad2c6d",
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "^0.7.0",
@@ -9594,8 +9594,8 @@
       }
     },
     "sass-loader": {
-      "version": "github:npetruzzelli-forks/sass-loader#472d09af2f8754d1c5c5d02975a25b72f1cbda27",
-      "from": "github:npetruzzelli-forks/sass-loader#472d09af2f8754d1c5c5d02975a25b72f1cbda27",
+      "version": "7.1.0",
+      "resolved": "github:npetruzzelli-forks/sass-loader#472d09af2f8754d1c5c5d02975a25b72f1cbda27",
       "dev": true,
       "requires": {
         "clone-deep": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "postcss-loader": "^3.0.0",
     "prettier": "^1.15.3",
     "sass-loader": "^7.1.0",
+    "serve-index": "^1.9.1",
     "style-loader": "^0.23.1",
     "webpack": "^4.27.0",
     "webpack-cli": "^3.1.2",

--- a/src/_assets/scripts/app.jsx
+++ b/src/_assets/scripts/app.jsx
@@ -15,6 +15,11 @@ class App extends Component {
         <ul>
           <li>
             <a href="/src">/src</a> - source code
+            <ul>
+              <li>
+                <a href="/src/node_modules">/node_modules</a>
+              </li>
+            </ul>
           </li>
           <li>
             <a href="/webpack-dev-server">/webpack-dev-server</a> - bundled code

--- a/tools/browsersync/config/src.bs-config.js
+++ b/tools/browsersync/config/src.bs-config.js
@@ -8,6 +8,7 @@ const serveIndexForRoute = require('../utils/serve-index-for-route')
  * `server.baseDir` should not serve unnecessary content.
  */
 const FAUX_SOURCE_PATH = path.resolve(__dirname, '../../../.tmp/faux-src')
+const NODE_MODULES_PATH = path.resolve(__dirname, '../../../node_modules')
 const SOURCE_PATH = path.resolve(__dirname, '../../../src')
 
 /*
@@ -37,6 +38,7 @@ const bsConfig = {
     baseDir: FAUX_SOURCE_PATH,
     directory: false,
     routes: {
+      '/src/node_modules': NODE_MODULES_PATH,
       '/src': SOURCE_PATH
     }
   },

--- a/tools/browsersync/utils/serve-index-for-route.js
+++ b/tools/browsersync/utils/serve-index-for-route.js
@@ -1,0 +1,26 @@
+const serveIndex = require('serve-index')
+
+var _serveDirectory = 0
+
+/**
+ * Based on, and intended to be consistent with, Browsersync's internal code for
+ * serving a directory listing for `baseDir`.
+ *
+ * @param {String} routeUrl
+ * @param {String} routeFsPath
+ * @returns {Function}
+ *
+ * @see {@link https://github.com/BrowserSync/browser-sync/blob/d60cd916ff1c64a69fddaa5cd2ca1061f066266e/packages/browser-sync/lib/server/static-server.js#L20-L36}
+ */
+function serveIndexForRoute(routeUrl, routeFsPath) {
+  return {
+    route: routeUrl,
+    handle: serveIndex(routeFsPath, {
+      icons: true,
+      view: 'details'
+    }),
+    id: `Server Route Directory Middleware for Browsersync - ${_serveDirectory++}`
+  }
+}
+
+module.exports = serveIndexForRoute

--- a/tools/webpack/config/base-webpack-config.js
+++ b/tools/webpack/config/base-webpack-config.js
@@ -179,7 +179,6 @@ function makeBaseWebpackConfig(cliEnvironment, argv, vars) {
       historyApiFallback: true,
       proxy: {
         '/src': {
-          pathRewrite: { '^/src': '' },
           target: `http://localhost:${DEV_SOURCE_PORT}`
         }
       }


### PR DESCRIPTION
This PR

-   Fixes an issue where the directory listing for the source directory did not navigate to the sub-directories in an expected manner.
-   Adds support for displaying directory listings for Browsersync Server routes in the same way that Browsersync already supports for the `baseDir`. This is accomplished with custom middleware.
-   Adds support for serving node modules